### PR TITLE
Specify encoding as utf-8 explicitly when opening files

### DIFF
--- a/klpt/att_analyze.py
+++ b/klpt/att_analyze.py
@@ -77,9 +77,9 @@ class ATTFST:
         self.identity_symbol = identity_symbol
         self.unknown_symbol = unknown_symbol
         try:
-            lines = [line.rstrip('\n') for line in codecs.getreader('utf-8')(gzip.open(attfile), errors='replace')]
+            lines = [line.rstrip('\n') for line in codecs.getreader("utf-8")(gzip.open(attfile, encoding = "utf-8"), errors='replace')]
         except:
-            f_lines = codecs.open(attfile, "r", encoding="utf-8")
+            f_lines = codecs.open(attfile, "r", encoding = "utf-8")
             lines = [line.rstrip('\n') for line in f_lines]
             f_lines.close()
         self.states = {}

--- a/klpt/configuration.py
+++ b/klpt/configuration.py
@@ -26,7 +26,7 @@ class Configuration:
 
         """
 
-        with open(klpt.get_data("data/default-options.json")) as options_file:
+        with open(klpt.get_data("data/default-options.json", encoding = "utf-8")) as options_file:
             self.options = json.load(options_file)
         
         self.unknown = None

--- a/klpt/configuration.py
+++ b/klpt/configuration.py
@@ -26,7 +26,7 @@ class Configuration:
 
         """
 
-        with open(klpt.get_data("data/default-options.json", encoding = "utf-8")) as options_file:
+        with open(klpt.get_data("data/default-options.json"), encoding = "utf-8") as options_file:
             self.options = json.load(options_file)
         
         self.unknown = None

--- a/klpt/preprocess.py
+++ b/klpt/preprocess.py
@@ -65,7 +65,7 @@ class Preprocess:
             numeral (str): the type of the numeral
         
         """
-        with open(klpt.get_data("data/preprocess_map.json")) as preprocess_file:
+        with open(klpt.get_data("data/preprocess_map.json"), encoding = "utf-8") as preprocess_file:
             self.preprocess_map = json.load(preprocess_file)
 
         configuration = Configuration({"dialect": dialect, "script": script, "numeral": numeral})
@@ -74,7 +74,7 @@ class Preprocess:
         self.numeral = configuration.numeral
         # self.preprocess_map = config.preprocess_map
 
-        with open(klpt.data_directory["stopwords"], "r") as f:
+        with open(klpt.data_directory["stopwords"], "r", encoding = "utf-8") as f:
             self.stopwords = json.load(f)[dialect][script]
 
     def standardize(self, text):

--- a/klpt/stem.py
+++ b/klpt/stem.py
@@ -66,13 +66,13 @@ class Stem:
         self.hunspell_flags = {"po": "pos", "is": "description", "ds": "formation", "st": "stem", "lem": "lemma"}
         if self.dialect == "Sorani" and self.script == "Arabic":
             self.huns = Hunspell("ckb-Arab", hunspell_data_dir=klpt.get_data("data/"))
-            with open(klpt.data_directory["morphemes"][self.dialect], "r") as f_morphemes:
+            with open(klpt.data_directory["morphemes"][self.dialect], "r", encoding = "utf-8") as f_morphemes:
                 self.light_verbs = json.load(f_morphemes)["Morphemes"]["light_verbs"][self.script]
         else:
             if not (self.dialect == "Kurmanji" and self.script == "Latin"):
                 raise Exception("Sorry, only Sorani dialect in the Arabic script and Kurmanji in the Latin script is supported now. Stay tuned for other dialects and scripts!")
             
-        with open(klpt.data_directory["morphemes"][self.dialect], "r") as f_morphemes:
+        with open(klpt.data_directory["morphemes"][self.dialect], "r", encoding = "utf-8") as f_morphemes:
             self.morphemes = json.load(f_morphemes)["Morphemes"]["Concatenated"][self.script]
 
     def stem(self, word, mark_unknown=False):

--- a/klpt/tokenize.py
+++ b/klpt/tokenize.py
@@ -49,10 +49,10 @@ class Tokenize:
     def __init__(self, dialect, script, numeral="Latin", separator='▁'):
 
         # validate parameters
-        with open(klpt.get_data("data/tokenize.json")) as tokenize_file:
+        with open(klpt.get_data("data/tokenize.json"), encoding = "utf-8") as tokenize_file:
             self.tokenize_map = json.load(tokenize_file)
 
-        with open(klpt.get_data("data/preprocess_map.json")) as preprocess_file:
+        with open(klpt.get_data("data/preprocess_map.json"), encoding = "utf-8") as preprocess_file:
             self.preprocess_map = json.load(preprocess_file)
 
         # sentence tokenizer variables
@@ -66,12 +66,12 @@ class Tokenize:
         self.digits = "([%s])"%"".join(list(set(list(self.preprocess_map["normalizer"]["universal"]["numerals"][numeral].values()))))
 
         # load lexicons
-        with open(klpt.data_directory["tokenize"][self.dialect][self.script], "r") as f_lexicon:
+        with open(klpt.data_directory["tokenize"][self.dialect][self.script], "r", encoding = "utf-8") as f_lexicon:
             self.lexicon = json.load(f_lexicon)["Lexicon"]
          
         self.mwe_lexicon = {lemma: form for lemma, form in self.lexicon.items() if "-" in lemma}
 
-        with open(klpt.data_directory["morphemes"][self.dialect], "r") as f_morphemes:
+        with open(klpt.data_directory["morphemes"][self.dialect], "r", encoding = "utf-8") as f_morphemes:
             self.morphemes = json.load(f_morphemes)["Morphemes"]["Concatenated"][self.script]
         
     

--- a/klpt/transliterate.py
+++ b/klpt/transliterate.py
@@ -60,10 +60,10 @@ class Transliterate:
         #     options = json.load(f)
         
         self.UNKNOWN = "�"
-        with open(klpt.get_data("data/wergor.json")) as f:
+        with open(klpt.get_data("data/wergor.json"), encoding = "utf-8") as f:
             self.wergor_configurations = json.load(f)
 
-        with open(klpt.get_data("data/preprocess_map.json")) as f:
+        with open(klpt.get_data("data/preprocess_map.json"), encoding = "utf-8") as f:
             self.preprocess_map = json.load(f)["normalizer"]
         
         configuration = Configuration({"dialect": dialect, "script": script, "numeral": numeral, "target_script": target_script, "unknown": unknown})

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import setup, find_packages
 from os import path
 
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+with open(path.join(this_directory, 'README.md'), encoding = "utf-8") as f:
     long_description = f.read()
 
-with open('requirements.txt') as f:
+with open('requirements.txt', encoding = "utf-8") as f:
     required = [req.strip() for req in f.read().splitlines() if req.strip()]
 
 setup(

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -14,7 +14,7 @@ import klpt
 class TestPreprocess(unittest.TestCase):
     """ Test unit for the Preprocess class"""
     def setUp(self):                    
-        with open(klpt.get_data("data/default-options.json")) as f:
+        with open(klpt.get_data("data/default-options.json"), encoding = "utf-8") as f:
             self.options = json.load(f)
 
     def tearDown(self):

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -12,10 +12,10 @@ import json
 class TestPreprocess(unittest.TestCase):
     """ Test unit for the Preprocess class"""
     def setUp(self):
-        with open(klpt.get_data("data/test_cases.json")) as f:
+        with open(klpt.get_data("data/test_cases.json"), encoding = "utf-8") as f:
             self.test_cases = json.load(f)
                     
-        with open(klpt.get_data("data/default-options.json")) as f:
+        with open(klpt.get_data("data/default-options.json"), encoding = "utf-8") as f:
             self.options = json.load(f)
 
     def tearDown(self):

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -27,7 +27,7 @@ class TestPreprocess(unittest.TestCase):
                 for case in self.test_cases["normalizer"][dialect][script]:
                     prep = Preprocess(dialect, script)
                     # print(case, prep.normalizer(case))
-                    self.assertEqual(prep.normalize(case), self.test_cases["normalizer"][dialect][script][case])
+                    self.assertCountEqual(prep.normalize(case), self.test_cases["normalizer"][dialect][script][case])
 
     def test_standardizer(self):
         # print("standardization")
@@ -36,14 +36,14 @@ class TestPreprocess(unittest.TestCase):
                 for case in self.test_cases["standardizer"][dialect][script]:
                     prep = Preprocess(dialect, script)
                     # print(case, prep.standardizer(case))
-                    self.assertEqual(prep.standardize(case), self.test_cases["standardizer"][dialect][script][case])
+                    self.assertCountEqual(prep.standardize(case), self.test_cases["standardizer"][dialect][script][case])
 
     def test_unify_numerals(self):
         # print("unify numerals")
         for numeral in self.options["numerals"]:
             for case in self.test_cases["numerals"][numeral]:
                 prep = Preprocess("Sorani", "Latin", numeral)
-                self.assertEqual(prep.unify_numerals(case), self.test_cases["numerals"][numeral][case])
+                self.assertCountEqual(prep.unify_numerals(case), self.test_cases["numerals"][numeral][case])
 
     def test_stopwords(self):
         # print("stopwords")
@@ -51,7 +51,7 @@ class TestPreprocess(unittest.TestCase):
             for script in self.options["scripts"]:
                 for case in self.test_cases["stopwords"][dialect][script]:
                     prep = Preprocess(dialect, script)
-                    self.assertEqual([token for token in case.split() if token not in prep.stopwords], self.test_cases["stopwords"][dialect][script][case])
+                    self.assertCountEqual([token for token in case.split() if token not in prep.stopwords], self.test_cases["stopwords"][dialect][script][case])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_stem.py
+++ b/tests/test_stem.py
@@ -28,24 +28,24 @@ class TestStem(unittest.TestCase):
                     # print(dialect, script)
                     # test the morphological analyzer
                     for test_case in self.test_cases["analyze"][dialect][script]:
-                        self.assertEqual(stemmer.analyze(test_case), self.test_cases["analyze"][dialect][script][test_case])
+                        self.assertCountEqual(stemmer.analyze(test_case), self.test_cases["analyze"][dialect][script][test_case])
                     
                     # test the stemmer
                     for test_case in self.test_cases["stem"][dialect][script]:
                         for case in test_case["cases"]:
-                            self.assertEqual(stemmer.stem(case, mark_unknown=test_case["parameters"]["mark_unknown"]), test_case["cases"][case])
+                            self.assertCountEqual(stemmer.stem(case, mark_unknown=test_case["parameters"]["mark_unknown"]), test_case["cases"][case])
                     
                     # test the lemmatizer
                     for test_case in self.test_cases["lemmatize"][dialect][script]:
                         # order of the lemmata may cause an error. Run many times.
-                        self.assertEqual(stemmer.lemmatize(test_case), self.test_cases["lemmatize"][dialect][script][test_case])
+                        self.assertCountEqual(stemmer.lemmatize(test_case), self.test_cases["lemmatize"][dialect][script][test_case])
 
                 elif dialect == "Kurmanji" and script == "Latin":
                     stemmer = Stem("Kurmanji", "Latin")
                     # NOTICE: the order in which att_analyze returns morphological analyses may make these tests fail. Make sure the tests are run enough times.
                     for test_case in self.test_cases["analyze"][dialect][script]:
                         # print(test_case, stemmer.analyze(test_case))
-                        self.assertEqual(stemmer.analyze(test_case), self.test_cases["analyze"][dialect][script][test_case])
+                        self.assertCountEqual(stemmer.analyze(test_case), self.test_cases["analyze"][dialect][script][test_case])
 
                 else: # otherwise, not supported currently
                     pass

--- a/tests/test_stem.py
+++ b/tests/test_stem.py
@@ -11,10 +11,10 @@ import klpt
 class TestStem(unittest.TestCase):
     """ Test unit for the Stem class"""
     def setUp(self):
-        with open(klpt.get_data("data/test_cases_stem.json")) as f:
+        with open(klpt.get_data("data/test_cases_stem.json"), encoding = "utf-8") as f:
             self.test_cases = json.load(f)
                     
-        with open(klpt.get_data("data/default-options.json")) as f:
+        with open(klpt.get_data("data/default-options.json"), encoding = "utf-8") as f:
             self.options = json.load(f)
 
     def tearDown(self):

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -11,10 +11,10 @@ import klpt
 class TestTokenize(unittest.TestCase):
     """ Test unit for the Preprocess class"""
     def setUp(self):
-        with open(klpt.get_data("data/test_cases_tokenize.json")) as f:
+        with open(klpt.get_data("data/test_cases_tokenize.json"), encoding = "utf-8") as f:
             self.test_cases = json.load(f)
                     
-        with open(klpt.get_data("data/default-options.json")) as f:
+        with open(klpt.get_data("data/default-options.json"), encoding = "utf-8") as f:
             self.options = json.load(f)
 
     def tearDown(self):

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -29,7 +29,7 @@ class TestTokenize(unittest.TestCase):
                     for test_case in self.test_cases["mwe_tokenize"][dialect][script]:
                         for case in test_case["cases"]:
                             # print(case, test_case["parameters"]["separator"], test_case["parameters"]["in_separator"], test_case["parameters"]["punct_marked"])
-                            self.assertEqual(tokenizer.mwe_tokenize(case, separator=test_case["parameters"]["separator"],
+                            self.assertCountEqual(tokenizer.mwe_tokenize(case, separator=test_case["parameters"]["separator"],
                                                                             in_separator=test_case["parameters"]["in_separator"],
                                                                             punct_marked=test_case["parameters"]["punct_marked"],
                                                                             keep_form=test_case["parameters"]["keep_form"]),
@@ -42,7 +42,7 @@ class TestTokenize(unittest.TestCase):
                     for case in self.test_cases["sent_tokenize"][dialect][script]:
                         tokenizer = Tokenize(dialect, script)
                         # print(case)
-                        self.assertEqual(tokenizer.sent_tokenize(case), self.test_cases["sent_tokenize"][dialect][script][case])
+                        self.assertCountEqual(tokenizer.sent_tokenize(case), self.test_cases["sent_tokenize"][dialect][script][case])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -35,15 +35,15 @@ class TestTransliterator(unittest.TestCase):
                     print(option, numeral)
                     for case in self.test_cases["transliterator"][option]["numerals"][numeral]:
                         wergor = Transliterate("Sorani", source_script, target_script, numeral=numeral)
-                        self.assertEqual(wergor.transliterate(case), self.test_cases["transliterator"][option]["numerals"][numeral][case])
+                        self.assertCountEqual(wergor.transliterate(case), self.test_cases["transliterator"][option]["numerals"][numeral][case])
             else:
                 for unk in self.test_cases["transliterator"][option]:
                     for case in self.test_cases["transliterator"][option][unk]:
                         wergor = Transliterate("Sorani", "Latin", "Arabic", unknown=unk)
-                        self.assertEqual(wergor.transliterate(case), self.test_cases["transliterator"][option][unk][case])
+                        self.assertCountEqual(wergor.transliterate(case), self.test_cases["transliterator"][option][unk][case])
 
                         wergor = Transliterate("Sorani", "Arabic", "Latin", unknown=unk)
-                        self.assertEqual(wergor.transliterate(case), self.test_cases["transliterator"][option][unk][case])
+                        self.assertCountEqual(wergor.transliterate(case), self.test_cases["transliterator"][option][unk][case])
     
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -11,10 +11,10 @@ import klpt
 class TestTransliterator(unittest.TestCase):
     """ Test unit for the Preprocess module"""
     def setUp(self):
-        with open(klpt.get_data("data/test_cases.json")) as f:
+        with open(klpt.get_data("data/test_cases.json"), encoding = "utf-8") as f:
             self.test_cases = json.load(f)
                     
-        with open(klpt.get_data("data/default-options.json")) as f:
+        with open(klpt.get_data("data/default-options.json"), encoding = "utf-8") as f:
             self.options = json.load(f)
 
     def tearDown(self):


### PR DESCRIPTION
## Background:
I am trying to use KLPT from .NET! I am using https://github.com/pythonnet/pythonnet to do that and it works wonderfully. Look!

![image](https://user-images.githubusercontent.com/16880059/148661310-85aecaed-9dc3-4f50-b067-5f8521328482.png)

The problem I have is, whenever the python code wants to read from a file, it encounters an encoding problem:
```
''charmap' codec can't decode byte 0x90 in position 344: character maps to <undefined>'
```

My understanding is this might because the default encoding in .NET is UTF-16 and the files are in UTF-8.

## Fix:
The fix is very simple: Since the data files are all in utf-8, every time we open a file, we need to specify 'utf-8' as the encoding.