### PR TITLE
Build issue fix: replacing the cyhunspell package with a different package that maintains the same API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-cyhunspell>=2.0.1
+chunspell


### PR DESCRIPTION
[Cyhunspell](https://github.com/MSeal/cython_hunspell) is no longer maintained and cannot be easily built for recent versions of Python, which causes the installation of klpt to break. This pull request provides a quick fix by replacing cyhunspell with a more up-to-date, actively maintained version of the wrapper.
[cHunSpell](https://pypi.org/project/chunspell) is another wrapper around Hunspell that has fewer dependencies and no build issues for Python 3.11 and 3.12. It maintains the same API as [cython_hunspell](https://github.com/MSeal/cython_hunspell), so there is no need for any change from the KLPT side. I have tested all the functions from the Stem module, and they all work fine with it.