### PR TITLE
Build issue fix: replacing the cyhunspell package with a different package that maintains the same API

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,8 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9"] # cyhunspell is not available for python 3.10 yet!
-
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"] # chunspell build on 3.7 and later versions of Python
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-cyhunspell>=2.0.1
+chunspell==2.0.4


### PR DESCRIPTION
[Cyhunspell](https://github.com/MSeal/cython_hunspell) is no longer maintained and cannot be easily built for recent versions of Python, which causes the installation of klpt to break. This pull request provides a quick fix by replacing cyhunspell with a more up-to-date, actively maintained version of the wrapper.

[cHunSpell](https://pypi.org/project/chunspell) is another wrapper around Hunspell that has fewer dependencies and no build issues for Python 3.11 and 3.12. It maintains the same API as [cython_hunspell](https://github.com/MSeal/cython_hunspell), so there is no need for any change from the KLPT side. I have tested all the functions from the Stem module, and they all work fine with it.

I have also updated GitHub Actions workflow to build and test the project using Python 3.8 and later versions. Python 3.7 has reached its end-of-life and is no longer supported.